### PR TITLE
Campaign & Unused Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ Chaoshead Update Awareness Day is annually on february 27, in order to spread aw
 
 ### Currently not supported
 
-- Campaign-only and dev-only elements are only partially supported
-  - Unsupported properties error upon file load (because the .lhs is can't be loaded)
-  - Unsupported objects will only error when placed in a row or column, otherwise they will simply show up with only their internal ID
 - Multiple path nodes in the same tile
   - While they do work in Levelhead, the visual bugs show that that isn't intended.
 - Setting properties on objects that don't have them

--- a/data/levelElements.tsv
+++ b/data/levelElements.tsv
@@ -121,7 +121,7 @@ Booster	118	#76	2	2	No	49	1	Used in Scooter Mode
 Brake	119	#77	2	2	No	49	1	Used in Scooter Mode
 Battery	120	#78	1	1	No	49,60	2	
 Charge Switch	121	#79	1	1	No	0,2,9	2	
-Refueler	122	#7A			No	27	1	Used in Airmail mode
+Refueler	122	#7A	2	1	No	27	1	Used in Airmail mode
 Golf Package	123	#7B	1	1	No	None	2	The round one used by golf mode. Actually called "Package" in the name combobulator (a different name is used here to have unique names for everything for better API).
 Ball Stopper	124	#7C	1	1	No	49	1	Used in Golf Mode
 Bumper	125	#7D	1	1	No	47,49,60	2	

--- a/data/levelElements.tsv
+++ b/data/levelElements.tsv
@@ -137,7 +137,7 @@ Regret Gate	133	#85	1	1	No	3,49,60	2
 2x2 Hardlight	135	#87	2	2	7	Inherit		
 2x2 Robo Factory	136	#88	2	2	101	Inherit		
 3x3 Robo Factory	137	#89	3	3	101	Inherit		
-Sweep Laser	138	#8A	1	1	No	49,50,52,60,67	1	Singel Laser Style Directions still missing
+Sweep Laser	138	#8A	1	1	No	31,49,50,52,60,67	1	
 Boombox	139	#8B	1	1	No	3,5,49,51,54,55,60,64,68,93,94,95,96,97,98	2	
 Recycler	140	#8C	1	1	No	49,60	1	
 Blopsack	141	#8D	1	1	No	49,60	2	

--- a/data/levelElements.tsv
+++ b/data/levelElements.tsv
@@ -117,13 +117,13 @@ Long Dropblock	103	#67	3	1	96	None
 Baddie Eyeswitch	115	#73	1	1	No	0,2,5,8,14,16,80,81,82,83,84	2	
 Bomb	116	#74	1	1	No	None	2	
 Package	117	#75	1	1	No	None	2	
-Booster	118	#76	2	2	No	49	1	Used in Scooter Mode
-Brake	119	#77	2	2	No	49	1	Used in Scooter Mode
+Booster	118	#76	2	2	No	49,60	1	Used in Scooter Mode
+Brake	119	#77	2	2	No	49,60	1	Used in Scooter Mode
 Battery	120	#78	1	1	No	49,60	2	
 Charge Switch	121	#79	1	1	No	0,2,9	2	
 Refueler	122	#7A	2	1	No	27	1	Used in Airmail mode
 Golf Package	123	#7B	1	1	No	None	2	The round one used by golf mode. Actually called "Package" in the name combobulator (a different name is used here to have unique names for everything for better API).
-Ball Stopper	124	#7C	1	1	No	49	1	Used in Golf Mode
+Ball Stopper	124	#7C	1	1	No	49,60	1	Used in Golf Mode
 Bumper	125	#7D	1	1	No	47,49,60	2	
 Canoodle Core	126	#7E	1	1	No	49,60	2	
 Wingarang	127	#7F	1	1	No	49,60	2	

--- a/data/properties.tsv
+++ b/data/properties.tsv
@@ -33,7 +33,7 @@ Movement	30	#1E	A		0	0	3	Simple	!	Horizontal	Vertical	Circle	Stationary	!	!	!	Sw
 Direction	31	#1F	A		3	0	3	Simple	!	Right	Up	Left	Down	!	!	!	Cromblers	
 Cooldown	32	#20	C		1	0.5	4	None									Cromblers	
 Time Offset	33	#21	C		0	0	4	None									(Look)cannon	
-Distance	34	#22	A														Doomarang	
+Distance	34	#22	A		2	2	5	None									Doomarang	
 Distance	35	#23	A		2	1	4	None									Swoopadoop, Blobfush, Whizzblade, Fireball	
 Speed	36	#24	A	Used for horizontal and vertical movement (types)	2	1	3	Simple	!	!	Slow	Medium	Fast	!	!	!	Swoopadoop, Blobfush, Whizzblade, Fireball	
 Active Speed	37	#25	B		200	-600	600	None									Path	
@@ -49,9 +49,9 @@ Powerup	46	#2E	A		0	0	6	Simple	!	None	Tiptow	Waylay	Zipper	Ripcord	Rebound	Shade
 Color	47	#2F	A		2	0	3	Simple	!	Blue	Gold	Fuchsia	Green	!	!	!	Hardlight, Rift, Key Chests, ...	
 Projectile	48	#30	A		0	0	4	Simple	!	Steel	Fire	Rubber	Rocket	Guided Missile	!	!	(Look)cannon	
 Receiving Channel	49	#31	B	Can be set to none.	-1	-1	999	Hybrid	None	-	-	-	-	-	-	-	Prizeblock, Hardlight, ...	
-Direction	50	#32	A								Vertical						Sweep Laser	
+Axis Direction	50	#32	A	Used for dual laser directions. Called "Direction" ingame, renamed to prevent clashing API names.	0	0	1	Simple	!	Horizontal	Vertical	!	!	!	!	!	Sweep Laser	
 Bass Pitch	51	#33	A	Also gets saved for the "melody" instrument. Called "Pitch" in-game.	7	0	23	List	Bass Pitch								Boombox	
-Laser Style	52	#34	A															
+Laser Style	52	#34	A		0	0	1	Simple	!	Dual	Single	!	!	!	!	!	Sweep Laser	
 ???	53	#35																
 Instrument	54	#36	A		0	0	2	Simple	!	Bass	Melody	Percussion	!	!	!	!	Boombox	
 Melody Pitch	55	#37	A	Also gets saved for the "bass" instrument. Called "Pitch" in-game.	7	0	28	List	Melody Pitch								Boombox	
@@ -61,7 +61,7 @@ Rotation Speed	58	#3A	B	Used for circular movement (type). Called "Speed" ingame
 Icon	59	#3B	A		0	0	49	List	Sign Icons								Sign	
 Switch Requirements	60	#3C	A		2	0	5	Simple	!	One Active	Any Active	All Active	One Inactive	Any Inactive	All Inactive	!	Prizeblock, Hardlight, ...	
 Visuals	61	#3D	A		2	0	16	List	Path Visuals								Path	
-Display	62	#3E	A														Instructions	
+Display	62	#3E	A		0	0	14	List	Instructions								Instructions	
 Song	63	#3F	A		9	0	37	Music									Jukebox	
 Sharp	64	#40	A		0	0	1	Simple	!	No	Yes	!	!	!	!	!	Boombox	
 Delay Seconds	65	#41	C		3	0.25	600	None									Waitswitch	
@@ -98,9 +98,9 @@ Beats Per Minute	95	#5F	A		120	60	240	None									Boombox
 Percussion Note	96	#60	A		0	0	14	List	Percussion								Boombox	
 Start Delay Beats	97	#61	C		0	0	1000	Hybrid	!	No Delay	-	-	-	-	-	-	Boombox	
 Repeat Count	98	#62	B	Always saved for some reason.	1	1	1000	Hybrid	!	!	Infinite	-	-	-	-	-	Boombox	
-Swipe Button Start	99	#63	A														Swipe Teacher	
-Swipe Button End	100	#64	A														Swipe Teacher	
-Button Direction	101	#65	A														Movement Teacher	
+Swipe Button Start	99	#63	A		0	0	2	Simple	!	Jump	Grab / Kick	Use Powerup	!	!	!	!	Swipe Teacher	
+Swipe Button End	100	#64	A		0	0	2	Simple	!	Jump	Grab / Kick	Use Powerup	!	!	!	!	Swipe Teacher	
+Button Direction	101	#65	A		0	0	7	List	Movement Teacher								Movement Teacher	
 Input	102	#66	A		0	0	6	Simple	!	Run Right	Run Left	Up	Down	Jump	Grab / Kick	Use Powerup	Input Switch	
 Players Required	103	#67	A		0	0	5	Simple	!	Any Players	All Players	Player 1	Player 2	Player 3	Player 4	!	Input Switch	
 Target Type	104	#68	A		0	0	2	Simple	!	GR-18	Package	Enemies	!	!	!	!	Lookannon	

--- a/data/properties.tsv
+++ b/data/properties.tsv
@@ -25,8 +25,8 @@ Speed	22	#16	B		300	100	700	None									Toe Slider
 Power	23	#17	B		2000	2000	3500	None									(Trig)blaster	
 Spin Speed	24	#18	B		0	-360	360	None									(Trig)blaster	
 Fire Delay	25	#19	C		0.5	0	2	None									Blaster	
-???	26	#20	A															
-Refills	27	#21	A														Refeuler	
+???	26	#1A	A															
+Refills	27	#1B	A		0	0	30	Hybrid	!	Infinite	-	-	-	-	-	-	Refeuler	
 Rift ID	28	#1C	B		0	-1	999	Hybrid	None	-	-	-	-	-	-	-	Rift	
 Destination Rift ID	29	#1D	B	Defaults to 0 (it doesn't get saved if it's 0), while the editor default is 1	0	-1	999	Hybrid	None	-	-	-	-	-	-	-	Rift	
 Movement	30	#1E	A		0	0	3	Simple	!	Horizontal	Vertical	Circle	Stationary	!	!	!	Swoopadoop, Blobfush, Whizzblade, Fireball	

--- a/data/propertyLists.tsv
+++ b/data/propertyLists.tsv
@@ -54,4 +54,4 @@ Value(the number the mappnig in the lists to the right correspond to. A mapping 
 52										
 53										
 54										
-55											
+55										

--- a/data/propertyLists.tsv
+++ b/data/propertyLists.tsv
@@ -1,57 +1,57 @@
-Value(the number the mappnig in the lists to the right correspond to. A mapping of ! means out of range)	Jingle	Bass Pitch	Melody Pitch	Percussion	Items	Path Visuals	Enemies	Sign Icons
-0	Reveal	C2	C4	Kick Deep	Armor Plate	None	Vacrat	Danger
-1	Surprise	D2	D4	Kick Thump	Ripcord	Mudwood	Flipwip	Hazard
-2	Long Sad	E2	E4	Snare Tough	Tiptow	Cable	Blopfush	Enemy
-3	Short Sad	F2	F4	Snare Slap	Zipper	Spurkles	Flapjack	Path
-4	Long Happy	G2	G4	Snare Reverb	Waylay	Square Chains	Lizumi	Puzzle
-5	Short Happy	A2	A4	Hi-Hat Tap	Rebound	Alien Webbing	Swoopadoop	Look
-6	Crashlands Happy	B2	B4	Hi-Hat Close	Shade	Wiggly Vines	Canoodle	Package
-7	Crashlands Sad	C3	C5	Hi-Hat Open	DBot	Digital Blue	Popjaw	Key
-8	Crashlands Reveal	D3	D5	Crash	Recycler	Digital Gold	Scrubb	Throw
-9	Chill Reveal	E3	E5	Tom Low	Slurb Juice	Digital Fuchsia	Ocula	Boom
-10	Chil Success	F3	F5	Tom High	Lectroshield	Digital Green	Jabber	Question
-11	Tense Reveal	G3	G5	Tom Low Soft	Bomb	Frozen	Mad Jabber	BUDD-E
-12	Tense Success	A3	A5	Tom High Soft	Keycard	Maximum Power	Peanut	Jem
-13	Spooky Reveal	B3	B5	Click	Battery	Bones	Thorny Peanut	Zipper
-14	Spooky Success	C4	C6	Click Soft	Blopsack	Merriment	Explosive Peanut	Waylay
-15	Puzzle Success	D4	D6		Canoodle Core	Fortress		Sneak
-16		E4	E6		Flapsack	Rope		Propeller
-17		F4	F6		Flipegg			Jet
-18		G4	G6		Lizumi thorn			Popjaw
-19		A4	A6		Pop Medaillon			Blopfush
-20		B4	B6		Wingarang			Swoopadoop
-21		C5	C7		Vacsteak			Vacrat
-22		A1	C3		Squished Ocula			Flipwip
-23		B1	D3		Squished Scrubb			Lizumi
-24			E3		Stackable Armor			Grab
-25			F3					Jump
-26			G3					Flapjack
-27			A3					No
-28			B3					Reset
-29								Yes
-30								Jet
-31								Ocula
-32								Scrubb
-33								Sprint
-34								Key Chest
-35								Goal
-36								GR-18
-37								Heart
-38								Blue
-39								Gold
-40								Fuchsia
-41								Green
-42								Music
-43								Jabber
-44								Puncher
-45								Canoodle
-46								Shade
-47								Peanut
-48								Shade Rune
-49								Use Powerup
-50								
-51								
-52								
-53								
-54								
-55								
+Value(the number the mappnig in the lists to the right correspond to. A mapping of ! means out of range)	Jingle	Bass Pitch	Melody Pitch	Percussion	Items	Path Visuals	Enemies	Sign Icons	Instructions	Movement Teacher
+0	Reveal	C2	C4	Kick Deep	Armor Plate	None	Vacrat	Danger	Grappler	Right
+1	Surprise	D2	D4	Kick Thump	Ripcord	Mudwood	Flipwip	Hazard	Powerup	Up + Right
+2	Long Sad	E2	E4	Snare Tough	Tiptow	Cable	Blopfush	Enemy	Box Jump	Up
+3	Short Sad	F2	F4	Snare Slap	Zipper	Spurkles	Flapjack	Path	Movement	Up + Left
+4	Long Happy	G2	G4	Snare Reverb	Waylay	Square Chains	Lizumi	Puzzle	Jump	Left
+5	Short Happy	A2	A4	Hi-Hat Tap	Rebound	Alien Webbing	Swoopadoop	Look	Kick	Down + Left
+6	Crashlands Happy	B2	B4	Hi-Hat Close	Shade	Wiggly Vines	Canoodle	Package	Jet	Down
+7	Crashlands Sad	C3	C5	Hi-Hat Open	DBot	Digital Blue	Popjaw	Key	Propeller	Down + Right
+8	Crashlands Reveal	D3	D5	Crash	Recycler	Digital Gold	Scrubb	Throw	Rebound Shoot	
+9	Chill Reveal	E3	E5	Tom Low	Slurb Juice	Digital Fuchsia	Ocula	Boom	Rebound Bounce	
+10	Chil Success	F3	F5	Tom High	Lectroshield	Digital Green	Jabber	Question	Drop	
+11	Tense Reveal	G3	G5	Tom Low Soft	Bomb	Frozen	Mad Jabber	BUDD-E	Kick Jump	
+12	Tense Success	A3	A5	Tom High Soft	Keycard	Maximum Power	Peanut	Jem	Sprint	
+13	Spooky Reveal	B3	B5	Click	Battery	Bones	Thorny Peanut	Zipper	Hang	
+14	Spooky Success	C4	C6	Click Soft	Blopsack	Merriment	Explosive Peanut	Waylay	Fan Hover Down	
+15	Puzzle Success	D4	D6		Canoodle Core	Fortress		Sneak		
+16		E4	E6		Flapsack	Rope		Propeller		
+17		F4	F6		Flipegg			Jet		
+18		G4	G6		Lizumi thorn			Popjaw		
+19		A4	A6		Pop Medaillon			Blopfush		
+20		B4	B6		Wingarang			Swoopadoop		
+21		C5	C7		Vacsteak			Vacrat		
+22		A1	C3		Squished Ocula			Flipwip		
+23		B1	D3		Squished Scrubb			Lizumi		
+24			E3		Stackable Armor			Grab		
+25			F3					Jump		
+26			G3					Flapjack		
+27			A3					No		
+28			B3					Reset		
+29								Yes		
+30								Jet		
+31								Ocula		
+32								Scrubb		
+33								Sprint		
+34								Key Chest		
+35								Goal		
+36								GR-18		
+37								Heart		
+38								Blue		
+39								Gold		
+40								Fuchsia		
+41								Green		
+42								Music		
+43								Jabber		
+44								Puncher		
+45								Canoodle		
+46								Shade		
+47								Peanut		
+48								Shade Rune		
+49								Use Powerup		
+50										
+51										
+52										
+53										
+54										
+55											


### PR DESCRIPTION
This Pull Request fixes a lot of the "broken" properties, that are only used on campaign or otherwise unused objects. This also adds the "single laser" directions to the (unused) sweep laser, as i noticed that was missing too.

